### PR TITLE
Add unit tests for qunar.tc.qmq.utils.RetrySubjectUtils

### DIFF
--- a/qmq-common/src/test/java/qunar/tc/qmq/utils/utils/RetrySubjectUtilsTest.java
+++ b/qmq-common/src/test/java/qunar/tc/qmq/utils/utils/RetrySubjectUtilsTest.java
@@ -1,0 +1,44 @@
+package qunar.tc.qmq.utils.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static qunar.tc.qmq.utils.RetrySubjectUtils.*;
+
+public class RetrySubjectUtilsTest {
+
+    @Test
+    public void testGetRealSubject() {
+        assertNull(getRealSubject(null));
+
+        assertEquals("%RETRY", getRealSubject("%RETRY"));
+        assertEquals("foo", getRealSubject("%DEAD_RETRY%foo%bar"));
+    }
+
+    @Test
+    public void testParseSubjectAndGroup() {
+        assertNull(parseSubjectAndGroup(null));
+        assertNull(parseSubjectAndGroup("%DEAD_RETRY"));
+
+        assertArrayEquals(new String[]{"foo", "bar"}, parseSubjectAndGroup("%DEAD_RETRY%foo%bar"));
+    }
+
+    @Test
+    public void testIsRealSubject() {
+        assertFalse(isRealSubject(null));
+        assertFalse(isRealSubject("%RETRY"));
+        assertFalse(isRealSubject("%DEAD_RETRY"));
+
+        assertTrue(isRealSubject("foo"));
+    }
+
+    @Test
+    public void testBuildRetrySubject() {
+        assertEquals("%RETRY%foo%baz", buildRetrySubject("foo", "baz"));
+    }
+
+    @Test
+    public void testBuildDeadRetrySubject() {
+        assertEquals("%DEAD_RETRY%foo%baz", buildDeadRetrySubject("foo", "baz"));
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that qunar.tc.qmq.utils.RetrySubjectUtils is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important.